### PR TITLE
Add support for changing the webserver host

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,9 +15,10 @@ var rootCmd = &cobra.Command{
 		dark, _ := cmd.Flags().GetBool("dark")
 		browser, _ := cmd.Flags().GetBool("browser")
 		openReadme, _ := cmd.Flags().GetBool("readme")
+		host, _ := cmd.Flags().GetString("host")
 		port, _ := cmd.Flags().GetInt("port")
 
-		client := pkg.Client{Dark: dark, OpenBrowser: browser, Port: port, OpenReadme: openReadme}
+		client := pkg.Client{Dark: dark, OpenBrowser: browser, Host: host, Port: port, OpenReadme: openReadme}
 
 		var file string
 		if len(args) == 1 {
@@ -39,5 +40,6 @@ func init() {
 	rootCmd.Flags().BoolP("dark", "d", false, "Activate darkmode")
 	rootCmd.Flags().BoolP("browser", "b", true, "Open new browser tab")
 	rootCmd.Flags().BoolP("readme", "r", true, "Open readme if no file provided")
+	rootCmd.Flags().StringP("host", "H", "localhost", "Host to use")
 	rootCmd.Flags().IntP("port", "p", 6419, "Port to use")
 }

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -3,6 +3,7 @@ package pkg
 type Client struct {
 	Dark        bool
 	OpenBrowser bool
+	Host        string
 	Port        int
 	OpenReadme  bool
 }

--- a/pkg/webserver.go
+++ b/pkg/webserver.go
@@ -62,7 +62,7 @@ func (client *Client) Serve(file string) error {
 		}
 	})
 
-	addr := fmt.Sprintf("http://localhost:%d/", client.Port)
+	addr := fmt.Sprintf("http://%s:%d/", client.Host, client.Port)
 	if file == "" {
 		// If README.md exists then open README.md at beginning
 		readme := "README.md"


### PR DESCRIPTION
Hello @chrishrb, I very recently found this project, and it was a blessing for me since the original grip project wasn't working properly with the GitHub API for me and my Neovim config. However, something missing from the original grip is the ability to set the host for the previewer web server, which is really useful in cases like connecting/programming on another computer via SSH. So I forked the project since it was a simple change and addition.

This PR adds this small missing feature for the project to the upstream so more people can make use of it.