### PR TITLE
refactor: remove the necessity of flake-utils

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1734424634,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,25 +2,35 @@
   description = "go-grip - render your markdown files local";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
   };
-  outputs = { self, nixpkgs, ... }@inputs: inputs.flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        go-grip = pkgs.buildGoModule {
-          name = "go-grip";
-          src = self;
-          # Only for updating vendorHas
-          # vendorHash = "sha256-RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR=";
-          vendorHash = "sha256-aU6vo/uqJzctD7Q8HPFzHXVVJwMmlzQXhAA6LSkRAow=";
-        };
+  outputs = {
+    self,
+    nixpkgs,
+    ...
+  }: let
+    systems = [
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    forAllSystems = f:
+      nixpkgs.lib.genAttrs systems (system: let
+        pkgs = import nixpkgs {inherit system;};
       in
-      {
-        packages.default = go-grip;
-        devShells.default = pkgs.mkShell {
-          nativeBuildInputs = [ go-grip ];
-        };
-      }
-    );
+        f pkgs);
+  in {
+    packages = forAllSystems (pkgs: {
+      default = pkgs.buildGoModule {
+        name = "go-grip";
+        src = self;
+        # Only for updating vendorHas
+        # vendorHash = "sha256-RRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRRR=";
+        vendorHash = "sha256-aU6vo/uqJzctD7Q8HPFzHXVVJwMmlzQXhAA6LSkRAow=";
+      };
+    });
+    devShells = forAllSystems (pkgs: {
+      default = self.packages.${pkgs.system}.default;
+    });
+  };
 }


### PR DESCRIPTION
Hello!

This PR removes the Nix dependency of [`flake-utils`](https://github.com/numtide/flake-utils) to pass the package derivation and dev shell for the default systems. I recently noticed that the project uses this dependency in a way that can be considered overkill, since we are just using it to infix the system type in the `devShells` and `packages` output, which can be easily replaced with a utility function.

Removing the `flake-utils` also makes consumers of the flake don't need another dependency and/or another version of the utility in their lock files.

Other reasons to not use `flake-utils` can be found in this blog post: https://ayats.org/blog/no-flake-utils

This doesn't change anything for consumers of this flake, the derivations and ways to use this package are the same (aka. no breaking changes to the Nix flake consumers)