### PR TITLE
 Export Generated HTML & Additional Features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vendor
 result
 bin
+output
+go-grip

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor
 result
 bin/
-output
+output/
 go-grip
+tests-local/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 vendor
 result
-bin
+bin/
 output
-./go-grip
+go-grip

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ vendor
 result
 bin
 output
-go-grip
+./go-grip

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all run format emojiscraper build vendor test compile format lint clean
+.PHONY: all run format emojiscraper build vendor test compile format lint clean release
 
 # If the first argument is "run"...
 ifeq (run,$(firstword $(MAKECMDGOALS)))
@@ -9,7 +9,16 @@ ifeq (run,$(firstword $(MAKECMDGOALS)))
 endif
 
 GOCMD=go
-LDFLAGS="-s -w ${LDFLAGS_OPT}"
+
+# pkgver variables
+VERSION=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+LDFLAGS=-s -w
+VERSION_FLAGS=-X github.com/chrishrb/go-grip/cmd.Version=$(VERSION) \
+	      -X github.com/chrishrb/go-grip/cmd.CommitHash=$(COMMIT) \
+	      -X github.com/chrishrb/go-grip/cmd.BuildDate=$(BUILD_DATE) \
+	      FULL_LDFLAGS=-ldflags "$(LDFLAGS) $(VERSION_FLAGS)"
 
 all: vendor build format lint ## Format, lint and build
 
@@ -20,31 +29,46 @@ emojiscraper: ## Run emojiscraper
 	go run -tags debug main.go emojiscraper defaults/static/emojis pkg/emoji_map.go
 
 build: ## Build
-	go build -tags debug -o bin/go-grip main.go
+	$(GOCMD) build -tags debug $(FULL_LDFLAGS) -o bin/go-grip main.go
 
 vendor: ## Vendor
-	go mod vendor
+	$(GOCMD) mod vendor
 
 test: ## Test
-	${GOCMD} test ./...
+	$(GOCMD) test ./...
 
 compile: ## Compile for every OS and Platform
 	echo "Compiling for every OS and Platform"
-	GOOS=darwin GOARCH=amd64 go build -o bin/go-grip-darwin-amd64 main.go
-	GOOS=darwin GOARCH=arm64 go build -o bin/go-grip-darwin-arm64 main.go
-	GOOS=linux GOARCH=amd64 go build -o bin/go-grip-linux-amd64 main.go
-	GOOS=linux GOARCH=arm64 go build -o bin/go-grip-linux-arm64 main.go
-	GOOS=windows GOARCH=amd64 go build -o bin/go-grip-windows-amd64.exe main.go
-	GOOS=windows GOARCH=arm64 go build -o bin/go-grip-windows-arm64.exe main.go
+	GOOS=darwin GOARCH=amd64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/go-grip-darwin-amd64 main.go
+	GOOS=darwin GOARCH=arm64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/go-grip-darwin-arm64 main.go
+	GOOS=linux GOARCH=amd64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/go-grip-linux-amd64 main.go
+	GOOS=linux GOARCH=arm64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/go-grip-linux-arm64 main.go
+	GOOS=windows GOARCH=amd64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/go-grip-windows-amd64.exe main.go
+	GOOS=windows GOARCH=arm64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/go-grip-windows-arm64.exe main.go
+
+release: clean
+	@echo "Creating release $(VERSION)"
+	@if echo $(VERSION) | grep -q "dirty"; then \
+		echo "Error: dirty repo."; \
+	fi
+	mkdir -p bin/release
+	GOOS=darwin GOARCH=amd64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/release/go-grip-$(VERSION)-darwin-amd64 main.go
+	GOOS=darwin GOARCH=arm64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/release/go-grip-$(VERSION)-darwin-arm64 main.go
+	GOOS=linux GOARCH=amd64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/release/go-grip-$(VERSION)-linux-amd64 main.go
+	GOOS=linux GOARCH=arm64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/release/go-grip-$(VERSION)-linux-arm64 main.go
+	GOOS=windows GOARCH=amd64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/release/go-grip-$(VERSION)-windows-amd64.exe main.go
+	GOOS=windows GOARCH=arm64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/release/go-grip-$(VERSION)-windows-arm64.exe main.go
+	@echo "Release $(VERSION) created in bin/release/"
 
 format: ## Format code
-	${GOCMD} fmt ./...
+	$(GOCMD) fmt ./...
 
 lint: ## Run linter
 	golangci-lint run
 
 clean: ## Cleanup build dir
-	rm -r bin/
+	rm -rf bin/
+	@go mod tidy
 
 help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <h3 align="center">go-grip</h3>
 
   <p align="center">
-    Render your markdown files local<br>- with the look of GitHub
+    Render your markdown files local<br> (github flavored rendering)
   </p>
 </div>
 
@@ -55,52 +55,119 @@ go install github.com/chrishrb/go-grip@latest
 > You can also use nix flakes to install this plugin.
 > More useful information [here](https://nixos.wiki/wiki/Flakes).
 
-## :hammer: Usage
+## :hammer: Commands and Usage
 
-By default, go-grip generates static HTML files from your markdown. To render a markdown file:
-
-```bash
-go-grip README.md
-```
-
-The generated HTML will be saved in your cache directory by default, and the browser will automatically open to view it. You can specify a custom output directory:
+### Basic Usage
 
 ```bash
-go-grip -o /path/to/output README.md
+
+go-grip [COMMAND] <args>
+
+# go-grip --help
+Available commands:
+  go-grip render FILE   - Generate static HTML from markdown
+  go-grip serve FILE    - Serve markdown via local HTTP server
+
+Available Commands:
+  completion   Generate the autocompletion script for the specified shell
+  emojiscraper Scrape emojis from gist
+  help         Help about any command
+  render       Render markdown document as html
+  serve        Run as a server and serve the markdown file
+  version      Print the version number of go-grip
+
+Flags:
+  -h, --help   help for go-grip
+
+Use "go-grip [command] --help" for more information about a command.
+
 ```
 
-To run as a server instead of generating static files:
+### Commands
+
+#### `render` - Generate static HTML Files
+
+Render a markdown file as static HTML.
+
+```
+Usage:
+  go-grip render [file|directory] [flags]
+
+Optional Flags:
+      --bounding-box    Add bounding box to HTML output (default true)
+  -d, --directory       Render all markdown files in directory
+  -h, --help            help for render
+  -o, --output string   Output directory for static files
+      --theme string    Select CSS theme [light/dark/auto] (default "auto")
+
+```
+
+Examples:
 
 ```bash
-go-grip --server README.md
+# render a single markdown file (opens it in a new browser tab)
+go-grip render README.md
+
+# specify custom output directory
+go-grip render README.md -o /path/to/output
+
+# render ALL markdown files in a directory
+go-grip render -d /path/to/my-note/ --output ./html-notes/
 ```
 
-You can also specify a port for the server:
+### `serve` - Live Preview Server
+
+Start a local server to render and serve the markdown file.
+
+The server will watch for changes to the file and automatically refresh the browser.
+This is useful for live previewing markdown as you edit it.
+
+```
+Usage:
+  go-grip serve FILE [flags]
+
+Flags:
+      --bounding-box   Add bounding box to HTML output (default true)
+  -b, --browser        Open browser tab automatically (default true)
+  -h, --help           help for serve
+  -H, --host string    Host to listen on (default "localhost")
+  -p, --port int       Port to listen on (default 6419)
+      --theme string   Select CSS theme [light/dark/auto] (default "auto")
+```
+
+Examples:
 
 ```bash
-go-grip --server -p 80 README.md
+# Start server for live preview of a file
+go-grip serve README.md
+
+# Specify host and port
+go-grip serve README.md -H 0.0.0.0 -p 8080
+
+# Disable automatic browser opening
+go-grip serve README.md -b=false
 ```
 
-To disable automatic browser opening:
+#### `-d/--directory` flag
 
-```bash
-go-grip -b=false README.md
-```
+When passed after the the `render` command, go-grip will:
 
-To activate dark mode:
+1. Generate HTML for all markdown files in the directory
+2. Create an index page linking to all rendered files
+3. Copy all required static assets (CSS, JS, images)
 
-```bash
-go-grip --theme dark README.md
-```
-
-## :pencil: Examples
+## :pencil: Screen shots
 
 <img src="./.github/docs/example-1.png" alt="examples" width="1000"/>
 
-## :bug: Known TODOs / Bugs
+## :bug: TODOs
 
 - [ ] Tests and refactoring
-- [ ] Make it possible to export the generated html
+- [ ] Move `theme` selection feature from CLI to a button in rendered HTML
+- [ ] Auto `Table of content` generation
+- [ ] Purged static files (Opens the door for Single HTML output)
+- [ ] Github flavored `blob` support
+- [ ] Output to Image
 
 ## :pushpin: Similar tools
 

--- a/README.md
+++ b/README.md
@@ -57,35 +57,41 @@ go install github.com/chrishrb/go-grip@latest
 
 ## :hammer: Usage
 
-To render the `README.md` file simply execute:
+By default, go-grip generates static HTML files from your markdown. To render a markdown file:
 
 ```bash
 go-grip README.md
-# or
-go-grip
 ```
 
-The browser will automatically open on http://localhost:6419. You can disable this behaviour with the `-b=false` option.
-
-You can also specify a port:
+The generated HTML will be saved in your cache directory by default, and the browser will automatically open to view it. You can specify a custom output directory:
 
 ```bash
-go-grip -p 80 README.md
+go-grip -o /path/to/output README.md
 ```
 
-or just open a file-tree with all available files in the current directory:
+To run as a server instead of generating static files:
 
 ```bash
-go-grip -r=false
+go-grip --server README.md
 ```
 
-It's also possible to activate the darkmode:
+You can also specify a port for the server:
 
 ```bash
-go-grip -d .
+go-grip --server -p 80 README.md
 ```
 
-To terminate the current server simply press `CTRL-C`.
+To disable automatic browser opening:
+
+```bash
+go-grip -b=false README.md
+```
+
+To activate dark mode:
+
+```bash
+go-grip --theme dark README.md
+```
 
 ## :pencil: Examples
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <br />
 <div align="center">
   <a href="#">
-    <img src=".github/docs/logo-1.png" alt="Logo" height="120">
+    <img src="https://raw.githubusercontent.com/chrishrb/go-grip/main/.github/docs/logo-1.png" alt="Logo" height="120">
   </a>
 
   <h3 align="center">go-grip</h3>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <br />
 <div align="center">
   <a href="#">
-    <img src="https://raw.githubusercontent.com/chrishrb/go-grip/main/.github/docs/logo-1.png" alt="Logo" height="120">
+    <img src=".github/docs/logo-1.png" alt="Logo" height="120">
   </a>
 
   <h3 align="center">go-grip</h3>

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/chrishrb/go-grip/pkg"
+	"github.com/spf13/cobra"
+)
+
+var directoryMode bool
+
+var renderCmd = &cobra.Command{
+	Use:   "render [file|directory]",
+	Short: "render md document as static html",
+	Long: `Render a markdown file(s) as static HTML.
+
+Basic usage:
+  go-grip render FILE				# generate static HTML for a single file
+  go-grip render FILE --output DIR	# specify output directory
+  go-grip render --directory DIR	# render all markdown files in directory`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		input := args[0]
+
+		parser := pkg.NewParser(theme)
+		srv := pkg.NewServer(host, port, theme, boundingBox, browser, parser)
+
+		if outputDir == "" {
+			cacheDir, err := os.UserCacheDir()
+			if err != nil {
+				return fmt.Errorf("failed to get cache directory: %v", err)
+			}
+			outputDir = filepath.Join(cacheDir, "go-grip")
+		}
+
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			return fmt.Errorf("failed to create output directory: %v", err)
+		}
+
+		if directoryMode {
+			return renderDirectory(srv, input, outputDir)
+		} else {
+			return renderSingleFile(srv, input, outputDir)
+		}
+	},
+}
+
+func renderSingleFile(srv *pkg.Server, filePath string, outputDir string) error {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return fmt.Errorf("file not found: %s - %v", filePath, err)
+	}
+
+	if info.IsDir() {
+		return fmt.Errorf("expected a file but got a directory '%s'. Use --directory flag for directories", filePath)
+	}
+
+	if filepath.Ext(filePath) != ".md" {
+		return fmt.Errorf("file '%s' must be a markdown file with .md extension", filePath)
+	}
+
+	if err := srv.GenerateSingleFile(filePath, outputDir); err != nil {
+		return fmt.Errorf("failed to generate HTML: %v", err)
+	}
+
+	return nil
+}
+
+func renderDirectory(srv *pkg.Server, dirPath string, outputDir string) error {
+	info, err := os.Stat(dirPath)
+	if err != nil {
+		return fmt.Errorf("directory not found: %s - %v", dirPath, err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("expected a directory but got a file '%s'. Remove --directory flag for single files", dirPath)
+	}
+
+	if err := srv.GenerateDirectoryFiles(dirPath, outputDir); err != nil {
+		return fmt.Errorf("failed to generate HTML files: %v", err)
+	}
+
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(renderCmd)
+
+	renderCmd.Flags().StringVar(&theme, "theme", "auto", "Select CSS theme [light/dark/auto]")
+	renderCmd.Flags().BoolVar(&boundingBox, "bounding-box", true, "Add bounding box to HTML output")
+	renderCmd.Flags().StringVarP(&outputDir, "output", "o", "", "Output directory for static files")
+	renderCmd.Flags().BoolVarP(&directoryMode, "directory", "d", false, "Render all markdown files in directory")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,51 +1,32 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
 
-	"github.com/chrishrb/go-grip/pkg"
 	"github.com/spf13/cobra"
 )
 
+var (
+	theme       string
+	boundingBox bool
+
+	browser bool
+	host    string
+	port    int
+
+	outputDir string
+)
+
 var rootCmd = &cobra.Command{
-	Use:   "go-grip [file]",
+	Use:   "go-grip [command] <args>",
 	Short: "Render markdown document as html",
-	Args:  cobra.MatchAll(cobra.OnlyValidArgs),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		theme, _ := cmd.Flags().GetString("theme")
-		browser, _ := cmd.Flags().GetBool("browser")
-		host, _ := cmd.Flags().GetString("host")
-		port, _ := cmd.Flags().GetInt("port")
-		boundingBox, _ := cmd.Flags().GetBool("bounding-box")
-		outputDir, _ := cmd.Flags().GetString("output")
-		runAsServer, _ := cmd.Flags().GetBool("server")
+	Long: `go-grip is a tool for rendering markdown documents as HTML.
 
-		var file string
-		if len(args) == 1 {
-			file = args[0]
-		} else {
-			return fmt.Errorf("no file specified")
-		}
+Available commands:
+  go-grip render FILE   - Generate static HTML from markdown
+  go-grip serve FILE    - Serve markdown via local HTTP server `,
 
-		parser := pkg.NewParser(theme)
-		srv := pkg.NewServer(host, port, theme, boundingBox, browser, parser)
-
-		if runAsServer {
-			return srv.Serve(file)
-		}
-
-		if outputDir == "" {
-			cacheDir, err := os.UserCacheDir()
-			if err != nil {
-				return fmt.Errorf("failed to get cache directory: %v", err)
-			}
-			outputDir = filepath.Join(cacheDir, "go-grip")
-		}
-
-		return srv.GenerateStaticSite(file, outputDir)
-	},
+	SilenceUsage: true,
 }
 
 func Execute() {
@@ -56,11 +37,6 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.Flags().String("theme", "auto", "Select css theme [light/dark/auto]")
-	rootCmd.Flags().BoolP("browser", "b", true, "Open new browser tab")
-	rootCmd.Flags().StringP("host", "H", "localhost", "Host to use")
-	rootCmd.Flags().IntP("port", "p", 6419, "Port to use")
-	rootCmd.Flags().Bool("bounding-box", true, "Add bounding box to HTML")
-	rootCmd.Flags().StringP("output", "o", "", "Output directory for static files (default: cache directory)")
-	rootCmd.Flags().Bool("server", false, "Run as server instead of generating static files")
+	// no flag is used as root,
+	//TODO: potential for backwards compatibility
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,8 @@ var rootCmd = &cobra.Command{
 		var file string
 		if len(args) == 1 {
 			file = args[0]
+		} else {
+			return fmt.Errorf("no file specified")
 		}
 
 		parser := pkg.NewParser(theme)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/chrishrb/go-grip/pkg"
+	"github.com/spf13/cobra"
+)
+
+var serveCmd = &cobra.Command{
+	Use:   "serve FILE",
+	Short: "Run as a server and serve the markdown file",
+	Long: `Start a local server to render and serve the markdown file.
+
+The server will watch for changes to the file and automatically refresh the browser.
+This is useful for live previewing markdown as you edit it.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		file := args[0]
+
+		parser := pkg.NewParser(theme)
+		srv := pkg.NewServer(host, port, theme, boundingBox, browser, parser)
+
+		if err := srv.Serve(file); err != nil {
+			return fmt.Errorf("server error: %v", err)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(serveCmd)
+
+	serveCmd.Flags().StringVar(&theme, "theme", "auto", "Select CSS theme [light/dark/auto]")
+	serveCmd.Flags().BoolVar(&boundingBox, "bounding-box", true, "Add bounding box to HTML output")
+	serveCmd.Flags().BoolVarP(&browser, "browser", "b", true, "Open browser tab automatically")
+	serveCmd.Flags().StringVarP(&host, "host", "H", "localhost", "Host to listen on")
+	serveCmd.Flags().IntVarP(&port, "port", "p", 6419, "Port to listen on")
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	Version    = "dev"
+	BuildDate  = "unknown"
+	CommitHash = "unknown"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of go-grip",
+	Long:  `Display the version information for go-grip.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("v%s (commit: %s, built: %s)\n", Version, CommitHash, BuildDate)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/defaults/templates/layout.html
+++ b/defaults/templates/layout.html
@@ -3,28 +3,28 @@
   <head>
     <meta charset="utf-8" />
     <title>go-grip - markdown preview</title>
-    <link rel="icon" type="image/x-icon" href="/static/images/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="static/images/favicon.ico" />
     {{if eq .Theme "dark" }}
-    <link rel="stylesheet" href="/static/css/github-markdown-dark.css" />
+    <link rel="stylesheet" href="static/css/github-markdown-dark.css" />
     <style>{{ .CssCodeDark }}</style>
     {{else if eq .Theme "light" }}
-    <link rel="stylesheet" href="/static/css/github-markdown-light.css" />
+    <link rel="stylesheet" href="static/css/github-markdown-light.css" />
     <style>{{ .CssCodeLight }}</style>
     {{else}}
     <link
       rel="stylesheet"
-      href="/static/css/github-markdown-light.css"
+      href="static/css/github-markdown-light.css"
       media="(prefers-color-scheme: light)"
     />
     <link
       rel="stylesheet"
-      href="/static/css/github-markdown-dark.css"
+      href="static/css/github-markdown-dark.css"
       media="(prefers-color-scheme: dark)"
     />
     <style media="(prefers-color-scheme: light)">{{ .CssCodeLight }}</style>
     <style media="(prefers-color-scheme: dark)">{{ .CssCodeDark }}</style>
     {{end}}
-    <link rel="stylesheet" href="/static/css/github-print.css" media="print" />
+    <link rel="stylesheet" href="static/css/github-print.css" media="print" />
   </head>
 
   <body class="markdown-body">

--- a/defaults/templates/mermaid/mermaid.html
+++ b/defaults/templates/mermaid/mermaid.html
@@ -3,7 +3,7 @@
     {{ .Content }}
   </div>
 
-  <script src="/static/js/mermaid.min.js"></script>
+  <script src="static/js/mermaid.min.js"></script>
   {{if eq .Theme "dark" }}
   <script>
     mermaid.initialize({startOnLoad:true, theme: 'dark'});

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,17 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
+<<<<<<< HEAD
 github.com/PuerkitoBio/goquery v1.10.0 h1:6fiXdLuUvYs2OJSvNRqlNPoBm6YABE226xrbavY5Wv4=
 github.com/PuerkitoBio/goquery v1.10.0/go.mod h1:TjZZl68Q3eGHNBA8CWaxAN7rOU1EbDz3CWuolcO5Yu4=
 github.com/PuerkitoBio/goquery v1.10.1 h1:Y8JGYUkXWTGRB6Ars3+j3kN0xg1YqqlwvdTV8WTFQcU=
 github.com/PuerkitoBio/goquery v1.10.1/go.mod h1:IYiHrOMps66ag56LEH7QYDDupKXyo5A8qrjIx3ZtujY=
 github.com/aarol/reload v1.1.3 h1:cL/LnKVJq1nb9DkOte9kRbPk2qmShFAAItyhvZRlxoA=
 github.com/aarol/reload v1.1.3/go.mod h1:TmwcyY3/j9gx1Tn3pGjanIQwd/weeFEJFNRTsn7wFDI=
+=======
+github.com/PuerkitoBio/goquery v1.10.1 h1:Y8JGYUkXWTGRB6Ars3+j3kN0xg1YqqlwvdTV8WTFQcU=
+github.com/PuerkitoBio/goquery v1.10.1/go.mod h1:IYiHrOMps66ag56LEH7QYDDupKXyo5A8qrjIx3ZtujY=
+>>>>>>> master
 github.com/aarol/reload v1.2.0 h1:zJZuWREX+rrB5V8o/PfQn1y9bG3rG8vmE0NeJl8aep0=
 github.com/aarol/reload v1.2.0/go.mod h1:3XL4gixCRx2VRXr4l3/qemjo2oWq8WxDRetd+EUkBcg=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=
@@ -17,6 +22,7 @@ github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxBp0T0eFw1RUQY=
+<<<<<<< HEAD
 github.com/andybalholm/cascadia v1.3.2 h1:3Xi6Dw5lHF15JtdcmAHD3i1+T8plmv7BQ/nsViSLyss=
 github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6lUvCFb+h7KvU=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
@@ -29,11 +35,22 @@ github.com/antchfx/htmlquery v1.3.4/go.mod h1:K9os0BwIEmLAvTqaNSua8tXLWRWZpocZIH
 github.com/antchfx/xmlquery v1.2.4/go.mod h1:KQQuESaxSlqugE2ZBcM/qn+ebIpt+d+4Xx7YcSGAIrM=
 github.com/antchfx/xmlquery v1.4.2 h1:MZKd9+wblwxfQ1zd1AdrTsqVaMjMCwow3IqkCSe00KA=
 github.com/antchfx/xmlquery v1.4.2/go.mod h1:QXhvf5ldTuGqhd1SHNvvtlhhdQLks4dD0awIVhXIDTA=
+=======
+github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
+github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
+github.com/antchfx/htmlquery v1.2.3/go.mod h1:B0ABL+F5irhhMWg54ymEZinzMSi0Kt3I2if0BLYa3V0=
+github.com/antchfx/htmlquery v1.3.4 h1:Isd0srPkni2iNTWCwVj/72t7uCphFeor5Q8nCzj1jdQ=
+github.com/antchfx/htmlquery v1.3.4/go.mod h1:K9os0BwIEmLAvTqaNSua8tXLWRWZpocZIH73OzWQbwM=
+github.com/antchfx/xmlquery v1.2.4/go.mod h1:KQQuESaxSlqugE2ZBcM/qn+ebIpt+d+4Xx7YcSGAIrM=
+>>>>>>> master
 github.com/antchfx/xmlquery v1.4.3 h1:f6jhxCzANrWfa93O+NmRWvieVyLs+R2Szfpy+YrZaww=
 github.com/antchfx/xmlquery v1.4.3/go.mod h1:AEPEEPYE9GnA2mj5Ur2L5Q5/2PycJ0N9Fusrx9b12fc=
 github.com/antchfx/xpath v1.1.6/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
 github.com/antchfx/xpath v1.1.8/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
+<<<<<<< HEAD
 github.com/antchfx/xpath v1.3.2/go.mod h1:i54GszH55fYfBmoZXapTHN8T8tkcHfRgLyVwwqzXNcs=
+=======
+>>>>>>> master
 github.com/antchfx/xpath v1.3.3 h1:tmuPQa1Uye0Ym1Zn65vxPgfltWb/Lxu2jeqIGteJSRs=
 github.com/antchfx/xpath v1.3.3/go.mod h1:i54GszH55fYfBmoZXapTHN8T8tkcHfRgLyVwwqzXNcs=
 github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
@@ -48,13 +65,19 @@ github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yA
 github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+<<<<<<< HEAD
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+=======
+>>>>>>> master
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+<<<<<<< HEAD
 github.com/gocolly/colly v1.2.0 h1:qRz9YAn8FIH0qzgNUw+HT9UN7wm1oF9OBAilwEWpyrI=
+=======
+>>>>>>> master
 github.com/gocolly/colly v1.2.0/go.mod h1:Hof5T3ZswNVsOHYmba1u03W65HDWgpV5HifSuueE0EA=
 github.com/gocolly/colly/v2 v2.1.0 h1:k0DuZkDoCsx51bKpRJNEmcxcp+W5N8ziuwGaSDuFoGs=
 github.com/gocolly/colly/v2 v2.1.0/go.mod h1:I2MuhsLjQ+Ex+IzK3afNS8/1qP3AedHOusRPcRdC5o0=
@@ -78,19 +101,28 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+<<<<<<< HEAD
 github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8 h1:4txT5G2kqVAKMjzidIabL/8KqjIK71yj30YOeuxLn10=
 github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
+=======
+>>>>>>> master
 github.com/gomarkdown/markdown v0.0.0-20241205020045-f7e15b2f3e62 h1:pbAFUZisjG4s6sxvRJvf2N7vhpCvx2Oxb3PmS6pDO1g=
 github.com/gomarkdown/markdown v0.0.0-20241205020045-f7e15b2f3e62/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+<<<<<<< HEAD
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
+=======
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+>>>>>>> master
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -115,8 +147,11 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+<<<<<<< HEAD
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+=======
+>>>>>>> master
 github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
 github.com/temoto/robotstxt v1.1.2 h1:W2pOjSJ6SWvldyEuiFXNxz3xZ8aiWX5LbfDiOFd7Fxg=
 github.com/temoto/robotstxt v1.1.2/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
@@ -151,14 +186,20 @@ golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
+<<<<<<< HEAD
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
+=======
+>>>>>>> master
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
+<<<<<<< HEAD
 golang.org/x/net v0.32.0 h1:ZqPmj8Kzc+Y6e0+skZsuACbx+wzMgo5MQsJh9Qd6aYI=
 golang.org/x/net v0.32.0/go.mod h1:CwU0IoeOlnQQWJ6ioyFrfRuomB8GKF6KbYXZVyeXNfs=
+=======
+>>>>>>> master
 golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -180,7 +221,10 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+<<<<<<< HEAD
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+=======
+>>>>>>> master
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
@@ -191,7 +235,10 @@ golang.org/x/telemetry v0.0.0-20240228155512-f48c80bd79b2/go.mod h1:TeRTkGYfJXct
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
+<<<<<<< HEAD
 golang.org/x/term v0.7.0/go.mod h1:P32HKFT3hSsZrRxla30E9HqToFYAQPCMs/zFMBUFqPY=
+=======
+>>>>>>> master
 golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
 golang.org/x/term v0.12.0/go.mod h1:owVbMEjm3cBLCHdkQu9b1opXd4ETQWc3BhuQGKgXgvU=
 golang.org/x/term v0.17.0/go.mod h1:lLRBjIVuehSbZlaOtGMbcMncT+aqLLLmKrsjNrUguwk=
@@ -221,7 +268,10 @@ golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+<<<<<<< HEAD
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+=======
+>>>>>>> master
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -245,8 +295,11 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+<<<<<<< HEAD
 google.golang.org/protobuf v1.36.0 h1:mjIs9gYtt56AzC4ZaffQuh88TZurBGhIJMBZGSxNerQ=
 google.golang.org/protobuf v1.36.0/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+=======
+>>>>>>> master
 google.golang.org/protobuf v1.36.1 h1:yBPeRvTftaleIgM3PZ/WBIZ7XM/eEYAaEyCwvyjq/gk=
 google.golang.org/protobuf v1.36.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,17 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
-<<<<<<< HEAD
-github.com/PuerkitoBio/goquery v1.10.0 h1:6fiXdLuUvYs2OJSvNRqlNPoBm6YABE226xrbavY5Wv4=
-github.com/PuerkitoBio/goquery v1.10.0/go.mod h1:TjZZl68Q3eGHNBA8CWaxAN7rOU1EbDz3CWuolcO5Yu4=
 github.com/PuerkitoBio/goquery v1.10.1 h1:Y8JGYUkXWTGRB6Ars3+j3kN0xg1YqqlwvdTV8WTFQcU=
 github.com/PuerkitoBio/goquery v1.10.1/go.mod h1:IYiHrOMps66ag56LEH7QYDDupKXyo5A8qrjIx3ZtujY=
-github.com/aarol/reload v1.1.3 h1:cL/LnKVJq1nb9DkOte9kRbPk2qmShFAAItyhvZRlxoA=
-github.com/aarol/reload v1.1.3/go.mod h1:TmwcyY3/j9gx1Tn3pGjanIQwd/weeFEJFNRTsn7wFDI=
-=======
-github.com/PuerkitoBio/goquery v1.10.1 h1:Y8JGYUkXWTGRB6Ars3+j3kN0xg1YqqlwvdTV8WTFQcU=
-github.com/PuerkitoBio/goquery v1.10.1/go.mod h1:IYiHrOMps66ag56LEH7QYDDupKXyo5A8qrjIx3ZtujY=
->>>>>>> master
 github.com/aarol/reload v1.2.0 h1:zJZuWREX+rrB5V8o/PfQn1y9bG3rG8vmE0NeJl8aep0=
 github.com/aarol/reload v1.2.0/go.mod h1:3XL4gixCRx2VRXr4l3/qemjo2oWq8WxDRetd+EUkBcg=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=
@@ -22,35 +13,16 @@ github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxBp0T0eFw1RUQY=
-<<<<<<< HEAD
-github.com/andybalholm/cascadia v1.3.2 h1:3Xi6Dw5lHF15JtdcmAHD3i1+T8plmv7BQ/nsViSLyss=
-github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6lUvCFb+h7KvU=
-github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
-github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
-github.com/antchfx/htmlquery v1.2.3/go.mod h1:B0ABL+F5irhhMWg54ymEZinzMSi0Kt3I2if0BLYa3V0=
-github.com/antchfx/htmlquery v1.3.3 h1:x6tVzrRhVNfECDaVxnZi1mEGrQg3mjE/rxbH2Pe6dNE=
-github.com/antchfx/htmlquery v1.3.3/go.mod h1:WeU3N7/rL6mb6dCwtE30dURBnBieKDC/fR8t6X+cKjU=
-github.com/antchfx/htmlquery v1.3.4 h1:Isd0srPkni2iNTWCwVj/72t7uCphFeor5Q8nCzj1jdQ=
-github.com/antchfx/htmlquery v1.3.4/go.mod h1:K9os0BwIEmLAvTqaNSua8tXLWRWZpocZIH73OzWQbwM=
-github.com/antchfx/xmlquery v1.2.4/go.mod h1:KQQuESaxSlqugE2ZBcM/qn+ebIpt+d+4Xx7YcSGAIrM=
-github.com/antchfx/xmlquery v1.4.2 h1:MZKd9+wblwxfQ1zd1AdrTsqVaMjMCwow3IqkCSe00KA=
-github.com/antchfx/xmlquery v1.4.2/go.mod h1:QXhvf5ldTuGqhd1SHNvvtlhhdQLks4dD0awIVhXIDTA=
-=======
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/antchfx/htmlquery v1.2.3/go.mod h1:B0ABL+F5irhhMWg54ymEZinzMSi0Kt3I2if0BLYa3V0=
 github.com/antchfx/htmlquery v1.3.4 h1:Isd0srPkni2iNTWCwVj/72t7uCphFeor5Q8nCzj1jdQ=
 github.com/antchfx/htmlquery v1.3.4/go.mod h1:K9os0BwIEmLAvTqaNSua8tXLWRWZpocZIH73OzWQbwM=
 github.com/antchfx/xmlquery v1.2.4/go.mod h1:KQQuESaxSlqugE2ZBcM/qn+ebIpt+d+4Xx7YcSGAIrM=
->>>>>>> master
 github.com/antchfx/xmlquery v1.4.3 h1:f6jhxCzANrWfa93O+NmRWvieVyLs+R2Szfpy+YrZaww=
 github.com/antchfx/xmlquery v1.4.3/go.mod h1:AEPEEPYE9GnA2mj5Ur2L5Q5/2PycJ0N9Fusrx9b12fc=
 github.com/antchfx/xpath v1.1.6/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
 github.com/antchfx/xpath v1.1.8/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
-<<<<<<< HEAD
-github.com/antchfx/xpath v1.3.2/go.mod h1:i54GszH55fYfBmoZXapTHN8T8tkcHfRgLyVwwqzXNcs=
-=======
->>>>>>> master
 github.com/antchfx/xpath v1.3.3 h1:tmuPQa1Uye0Ym1Zn65vxPgfltWb/Lxu2jeqIGteJSRs=
 github.com/antchfx/xpath v1.3.3/go.mod h1:i54GszH55fYfBmoZXapTHN8T8tkcHfRgLyVwwqzXNcs=
 github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
@@ -65,19 +37,10 @@ github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yA
 github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-<<<<<<< HEAD
-github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
-github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
-=======
->>>>>>> master
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
-<<<<<<< HEAD
-github.com/gocolly/colly v1.2.0 h1:qRz9YAn8FIH0qzgNUw+HT9UN7wm1oF9OBAilwEWpyrI=
-=======
->>>>>>> master
 github.com/gocolly/colly v1.2.0/go.mod h1:Hof5T3ZswNVsOHYmba1u03W65HDWgpV5HifSuueE0EA=
 github.com/gocolly/colly/v2 v2.1.0 h1:k0DuZkDoCsx51bKpRJNEmcxcp+W5N8ziuwGaSDuFoGs=
 github.com/gocolly/colly/v2 v2.1.0/go.mod h1:I2MuhsLjQ+Ex+IzK3afNS8/1qP3AedHOusRPcRdC5o0=
@@ -101,28 +64,15 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-<<<<<<< HEAD
-github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8 h1:4txT5G2kqVAKMjzidIabL/8KqjIK71yj30YOeuxLn10=
-github.com/gomarkdown/markdown v0.0.0-20240930133441-72d49d9543d8/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
-=======
->>>>>>> master
 github.com/gomarkdown/markdown v0.0.0-20241205020045-f7e15b2f3e62 h1:pbAFUZisjG4s6sxvRJvf2N7vhpCvx2Oxb3PmS6pDO1g=
 github.com/gomarkdown/markdown v0.0.0-20241205020045-f7e15b2f3e62/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-<<<<<<< HEAD
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
-github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
-=======
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
->>>>>>> master
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -147,11 +97,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-<<<<<<< HEAD
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-=======
->>>>>>> master
 github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
 github.com/temoto/robotstxt v1.1.2 h1:W2pOjSJ6SWvldyEuiFXNxz3xZ8aiWX5LbfDiOFd7Fxg=
 github.com/temoto/robotstxt v1.1.2/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
@@ -186,20 +131,10 @@ golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-<<<<<<< HEAD
-golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
-=======
->>>>>>> master
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
 golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
-<<<<<<< HEAD
-golang.org/x/net v0.32.0 h1:ZqPmj8Kzc+Y6e0+skZsuACbx+wzMgo5MQsJh9Qd6aYI=
-golang.org/x/net v0.32.0/go.mod h1:CwU0IoeOlnQQWJ6ioyFrfRuomB8GKF6KbYXZVyeXNfs=
-=======
->>>>>>> master
 golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -221,10 +156,6 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-<<<<<<< HEAD
-golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-=======
->>>>>>> master
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
@@ -235,10 +166,6 @@ golang.org/x/telemetry v0.0.0-20240228155512-f48c80bd79b2/go.mod h1:TeRTkGYfJXct
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
-<<<<<<< HEAD
-golang.org/x/term v0.7.0/go.mod h1:P32HKFT3hSsZrRxla30E9HqToFYAQPCMs/zFMBUFqPY=
-=======
->>>>>>> master
 golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=
 golang.org/x/term v0.12.0/go.mod h1:owVbMEjm3cBLCHdkQu9b1opXd4ETQWc3BhuQGKgXgvU=
 golang.org/x/term v0.17.0/go.mod h1:lLRBjIVuehSbZlaOtGMbcMncT+aqLLLmKrsjNrUguwk=
@@ -268,10 +195,6 @@ golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-<<<<<<< HEAD
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-=======
->>>>>>> master
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -295,15 +218,9 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-<<<<<<< HEAD
-google.golang.org/protobuf v1.36.0 h1:mjIs9gYtt56AzC4ZaffQuh88TZurBGhIJMBZGSxNerQ=
-google.golang.org/protobuf v1.36.0/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
-=======
->>>>>>> master
 google.golang.org/protobuf v1.36.1 h1:yBPeRvTftaleIgM3PZ/WBIZ7XM/eEYAaEyCwvyjq/gk=
 google.golang.org/protobuf v1.36.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
This PR implements the planned feature to export the generated HTML (#44), along with a few enhancements suggested in that thread:

- Adds the ability to export the rendered Markdown as a standalone HTML file.
- Changes the default command to `standalone` using `$CACHE_DIR/go-grip/` path  for `html sources`
- Introduces optional output dir `-o , --output` to exported static files to.
- Update readme accordingly
- other small modifications

