### PR TITLE
Refactor cli logic and add multiple features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 vendor
 result
-bin
+bin/
+output/
+go-grip
+tests-local/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all run format emojiscraper build vendor test compile format lint clean
+.PHONY: all run format emojiscraper build vendor test compile format lint clean release
 
 # If the first argument is "run"...
 ifeq (run,$(firstword $(MAKECMDGOALS)))
@@ -9,7 +9,16 @@ ifeq (run,$(firstword $(MAKECMDGOALS)))
 endif
 
 GOCMD=go
-LDFLAGS="-s -w ${LDFLAGS_OPT}"
+
+# pkgver variables
+VERSION=$(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+LDFLAGS=-s -w
+VERSION_FLAGS=-X github.com/chrishrb/go-grip/cmd.Version=$(VERSION) \
+	      -X github.com/chrishrb/go-grip/cmd.CommitHash=$(COMMIT) \
+	      -X github.com/chrishrb/go-grip/cmd.BuildDate=$(BUILD_DATE) \
+	      FULL_LDFLAGS=-ldflags "$(LDFLAGS) $(VERSION_FLAGS)"
 
 all: vendor build format lint ## Format, lint and build
 
@@ -20,31 +29,46 @@ emojiscraper: ## Run emojiscraper
 	go run -tags debug main.go emojiscraper defaults/static/emojis pkg/emoji_map.go
 
 build: ## Build
-	go build -tags debug -o bin/go-grip main.go
+	$(GOCMD) build -tags debug $(FULL_LDFLAGS) -o bin/go-grip main.go
 
 vendor: ## Vendor
-	go mod vendor
+	$(GOCMD) mod vendor
 
 test: ## Test
-	${GOCMD} test ./...
+	$(GOCMD) test ./...
 
 compile: ## Compile for every OS and Platform
 	echo "Compiling for every OS and Platform"
-	GOOS=darwin GOARCH=amd64 go build -o bin/go-grip-darwin-amd64 main.go
-	GOOS=darwin GOARCH=arm64 go build -o bin/go-grip-darwin-arm64 main.go
-	GOOS=linux GOARCH=amd64 go build -o bin/go-grip-linux-amd64 main.go
-	GOOS=linux GOARCH=arm64 go build -o bin/go-grip-linux-arm64 main.go
-	GOOS=windows GOARCH=amd64 go build -o bin/go-grip-windows-amd64.exe main.go
-	GOOS=windows GOARCH=arm64 go build -o bin/go-grip-windows-arm64.exe main.go
+	GOOS=darwin GOARCH=amd64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/go-grip-darwin-amd64 main.go
+	GOOS=darwin GOARCH=arm64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/go-grip-darwin-arm64 main.go
+	GOOS=linux GOARCH=amd64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/go-grip-linux-amd64 main.go
+	GOOS=linux GOARCH=arm64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/go-grip-linux-arm64 main.go
+	GOOS=windows GOARCH=amd64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/go-grip-windows-amd64.exe main.go
+	GOOS=windows GOARCH=arm64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/go-grip-windows-arm64.exe main.go
+
+release: clean
+	@echo "Creating release $(VERSION)"
+	@if echo $(VERSION) | grep -q "dirty"; then \
+		echo "Error: dirty repo."; \
+	fi
+	mkdir -p bin/release
+	GOOS=darwin GOARCH=amd64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/release/go-grip-$(VERSION)-darwin-amd64 main.go
+	GOOS=darwin GOARCH=arm64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/release/go-grip-$(VERSION)-darwin-arm64 main.go
+	GOOS=linux GOARCH=amd64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/release/go-grip-$(VERSION)-linux-amd64 main.go
+	GOOS=linux GOARCH=arm64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/release/go-grip-$(VERSION)-linux-arm64 main.go
+	GOOS=windows GOARCH=amd64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/release/go-grip-$(VERSION)-windows-amd64.exe main.go
+	GOOS=windows GOARCH=arm64 $(GOCMD) build $(FULL_LDFLAGS) -o bin/release/go-grip-$(VERSION)-windows-arm64.exe main.go
+	@echo "Release $(VERSION) created in bin/release/"
 
 format: ## Format code
-	${GOCMD} fmt ./...
+	$(GOCMD) fmt ./...
 
 lint: ## Run linter
 	golangci-lint run
 
 clean: ## Cleanup build dir
-	rm -r bin/
+	rm -rf bin/
+	@go mod tidy
 
 help: ## Display this help screen
 	@grep -h -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <h3 align="center">go-grip</h3>
 
   <p align="center">
-    Render your markdown files local<br>- with the look of GitHub
+    Render your markdown files local<br> (github flavored rendering)
   </p>
 </div>
 
@@ -55,46 +55,119 @@ go install github.com/chrishrb/go-grip@latest
 > You can also use nix flakes to install this plugin.
 > More useful information [here](https://nixos.wiki/wiki/Flakes).
 
-## :hammer: Usage
+## :hammer: Commands and Usage
 
-To render the `README.md` file simply execute:
-
-```bash
-go-grip README.md
-# or
-go-grip
-```
-
-The browser will automatically open on http://localhost:6419. You can disable this behaviour with the `-b=false` option.
-
-You can also specify a port:
+### Basic Usage
 
 ```bash
-go-grip -p 80 README.md
+
+go-grip [COMMAND] <args>
+
+# go-grip --help
+Available commands:
+  go-grip render FILE   - Generate static HTML from markdown
+  go-grip serve FILE    - Serve markdown via local HTTP server
+
+Available Commands:
+  completion   Generate the autocompletion script for the specified shell
+  emojiscraper Scrape emojis from gist
+  help         Help about any command
+  render       Render markdown document as html
+  serve        Run as a server and serve the markdown file
+  version      Print the version number of go-grip
+
+Flags:
+  -h, --help   help for go-grip
+
+Use "go-grip [command] --help" for more information about a command.
+
 ```
 
-or just open a file-tree with all available files in the current directory:
+### Commands
+
+#### `render` - Generate static HTML Files
+
+Render a markdown file as static HTML.
+
+```
+Usage:
+  go-grip render [file|directory] [flags]
+
+Optional Flags:
+      --bounding-box    Add bounding box to HTML output (default true)
+  -d, --directory       Render all markdown files in directory
+  -h, --help            help for render
+  -o, --output string   Output directory for static files
+      --theme string    Select CSS theme [light/dark/auto] (default "auto")
+
+```
+
+Examples:
 
 ```bash
-go-grip -r=false
+# render a single markdown file (opens it in a new browser tab)
+go-grip render README.md
+
+# specify custom output directory
+go-grip render README.md -o /path/to/output
+
+# render ALL markdown files in a directory
+go-grip render -d /path/to/my-note/ --output ./html-notes/
 ```
 
-It's also possible to activate the darkmode:
+### `serve` - Live Preview Server
+
+Start a local server to render and serve the markdown file.
+
+The server will watch for changes to the file and automatically refresh the browser.
+This is useful for live previewing markdown as you edit it.
+
+```
+Usage:
+  go-grip serve FILE [flags]
+
+Flags:
+      --bounding-box   Add bounding box to HTML output (default true)
+  -b, --browser        Open browser tab automatically (default true)
+  -h, --help           help for serve
+  -H, --host string    Host to listen on (default "localhost")
+  -p, --port int       Port to listen on (default 6419)
+      --theme string   Select CSS theme [light/dark/auto] (default "auto")
+```
+
+Examples:
 
 ```bash
-go-grip -d .
+# Start server for live preview of a file
+go-grip serve README.md
+
+# Specify host and port
+go-grip serve README.md -H 0.0.0.0 -p 8080
+
+# Disable automatic browser opening
+go-grip serve README.md -b=false
 ```
 
-To terminate the current server simply press `CTRL-C`.
+#### `-d/--directory` flag
 
-## :pencil: Examples
+When passed after the the `render` command, go-grip will:
+
+1. Generate HTML for all markdown files in the directory
+2. Create an index page linking to all rendered files
+3. Copy all required static assets (CSS, JS, images)
+
+## :pencil: Screen shots
 
 <img src="./.github/docs/example-1.png" alt="examples" width="1000"/>
 
-## :bug: Known TODOs / Bugs
+## :bug: TODOs
 
 - [ ] Tests and refactoring
-- [ ] Make it possible to export the generated html
+- [ ] Move `theme` selection feature from CLI to a button in rendered HTML
+- [ ] Auto `Table of content` generation
+- [ ] Purged static files (Opens the door for Single HTML output)
+- [ ] Github flavored `blob` support
+- [ ] Output to Image
 
 ## :pushpin: Similar tools
 

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/chrishrb/go-grip/pkg"
+	"github.com/spf13/cobra"
+)
+
+var directoryMode bool
+
+var renderCmd = &cobra.Command{
+	Use:   "render [file|directory]",
+	Short: "render md document as static html",
+	Long: `Render a markdown file(s) as static HTML.
+
+Basic usage:
+  go-grip render FILE				# generate static HTML for a single file
+  go-grip render FILE --output DIR	# specify output directory
+  go-grip render --directory DIR	# render all markdown files in directory`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		input := args[0]
+
+		parser := pkg.NewParser(theme)
+		srv := pkg.NewServer(host, port, theme, boundingBox, browser, parser)
+
+		if outputDir == "" {
+			cacheDir, err := os.UserCacheDir()
+			if err != nil {
+				return fmt.Errorf("failed to get cache directory: %v", err)
+			}
+			outputDir = filepath.Join(cacheDir, "go-grip")
+		}
+
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			return fmt.Errorf("failed to create output directory: %v", err)
+		}
+
+		if directoryMode {
+			return renderDirectory(srv, input, outputDir)
+		} else {
+			return renderSingleFile(srv, input, outputDir)
+		}
+	},
+}
+
+func renderSingleFile(srv *pkg.Server, filePath string, outputDir string) error {
+	info, err := os.Stat(filePath)
+	if err != nil {
+		return fmt.Errorf("file not found: %s - %v", filePath, err)
+	}
+
+	if info.IsDir() {
+		return fmt.Errorf("expected a file but got a directory '%s'. Use --directory flag for directories", filePath)
+	}
+
+	if filepath.Ext(filePath) != ".md" {
+		return fmt.Errorf("file '%s' must be a markdown file with .md extension", filePath)
+	}
+
+	if err := srv.GenerateSingleFile(filePath, outputDir); err != nil {
+		return fmt.Errorf("failed to generate HTML: %v", err)
+	}
+
+	return nil
+}
+
+func renderDirectory(srv *pkg.Server, dirPath string, outputDir string) error {
+	info, err := os.Stat(dirPath)
+	if err != nil {
+		return fmt.Errorf("directory not found: %s - %v", dirPath, err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("expected a directory but got a file '%s'. Remove --directory flag for single files", dirPath)
+	}
+
+	if err := srv.GenerateDirectoryFiles(dirPath, outputDir); err != nil {
+		return fmt.Errorf("failed to generate HTML files: %v", err)
+	}
+
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(renderCmd)
+
+	renderCmd.Flags().StringVar(&theme, "theme", "auto", "Select CSS theme [light/dark/auto]")
+	renderCmd.Flags().BoolVar(&boundingBox, "bounding-box", true, "Add bounding box to HTML output")
+	renderCmd.Flags().StringVarP(&outputDir, "output", "o", "", "Output directory for static files")
+	renderCmd.Flags().BoolVarP(&directoryMode, "directory", "d", false, "Render all markdown files in directory")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,30 +3,30 @@ package cmd
 import (
 	"os"
 
-	"github.com/chrishrb/go-grip/pkg"
 	"github.com/spf13/cobra"
 )
 
+var (
+	theme       string
+	boundingBox bool
+
+	browser bool
+	host    string
+	port    int
+
+	outputDir string
+)
+
 var rootCmd = &cobra.Command{
-	Use:   "go-grip [file]",
+	Use:   "go-grip [command] <args>",
 	Short: "Render markdown document as html",
-	Args:  cobra.MatchAll(cobra.OnlyValidArgs),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		theme, _ := cmd.Flags().GetString("theme")
-		browser, _ := cmd.Flags().GetBool("browser")
-		host, _ := cmd.Flags().GetString("host")
-		port, _ := cmd.Flags().GetInt("port")
-		boundingBox, _ := cmd.Flags().GetBool("bounding-box")
+	Long: `go-grip is a tool for rendering markdown documents as HTML.
 
-		var file string
-		if len(args) == 1 {
-			file = args[0]
-		}
+Available commands:
+  go-grip render FILE   - Generate static HTML from markdown
+  go-grip serve FILE    - Serve markdown via local HTTP server `,
 
-		parser := pkg.NewParser(theme)
-		server := pkg.NewServer(host, port, theme, boundingBox, browser, parser)
-		return server.Serve(file)
-	},
+	SilenceUsage: true,
 }
 
 func Execute() {
@@ -37,9 +37,6 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.Flags().String("theme", "auto", "Select css theme [light/dark/auto]")
-	rootCmd.Flags().BoolP("browser", "b", true, "Open new browser tab")
-	rootCmd.Flags().StringP("host", "H", "localhost", "Host to use")
-	rootCmd.Flags().IntP("port", "p", 6419, "Port to use")
-	rootCmd.Flags().Bool("bounding-box", true, "Add bounding box to HTML")
+	// no flag is used as root,
+	//TODO: potential for backwards compatibility
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/chrishrb/go-grip/pkg"
+	"github.com/spf13/cobra"
+)
+
+var serveCmd = &cobra.Command{
+	Use:   "serve FILE",
+	Short: "Run as a server and serve the markdown file",
+	Long: `Start a local server to render and serve the markdown file.
+
+The server will watch for changes to the file and automatically refresh the browser.
+This is useful for live previewing markdown as you edit it.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		file := args[0]
+
+		parser := pkg.NewParser(theme)
+		srv := pkg.NewServer(host, port, theme, boundingBox, browser, parser)
+
+		if err := srv.Serve(file); err != nil {
+			return fmt.Errorf("server error: %v", err)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(serveCmd)
+
+	serveCmd.Flags().StringVar(&theme, "theme", "auto", "Select CSS theme [light/dark/auto]")
+	serveCmd.Flags().BoolVar(&boundingBox, "bounding-box", true, "Add bounding box to HTML output")
+	serveCmd.Flags().BoolVarP(&browser, "browser", "b", true, "Open browser tab automatically")
+	serveCmd.Flags().StringVarP(&host, "host", "H", "localhost", "Host to listen on")
+	serveCmd.Flags().IntVarP(&port, "port", "p", 6419, "Port to listen on")
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	Version    = "dev"
+	BuildDate  = "unknown"
+	CommitHash = "unknown"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of go-grip",
+	Long:  `Display the version information for go-grip.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("%s (commit: %s, built: %s)\n", Version, CommitHash, BuildDate)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/defaults/templates/layout.html
+++ b/defaults/templates/layout.html
@@ -3,28 +3,28 @@
   <head>
     <meta charset="utf-8" />
     <title>go-grip - markdown preview</title>
-    <link rel="icon" type="image/x-icon" href="/static/images/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="static/images/favicon.ico" />
     {{if eq .Theme "dark" }}
-    <link rel="stylesheet" href="/static/css/github-markdown-dark.css" />
+    <link rel="stylesheet" href="static/css/github-markdown-dark.css" />
     <style>{{ .CssCodeDark }}</style>
     {{else if eq .Theme "light" }}
-    <link rel="stylesheet" href="/static/css/github-markdown-light.css" />
+    <link rel="stylesheet" href="static/css/github-markdown-light.css" />
     <style>{{ .CssCodeLight }}</style>
     {{else}}
     <link
       rel="stylesheet"
-      href="/static/css/github-markdown-light.css"
+      href="static/css/github-markdown-light.css"
       media="(prefers-color-scheme: light)"
     />
     <link
       rel="stylesheet"
-      href="/static/css/github-markdown-dark.css"
+      href="static/css/github-markdown-dark.css"
       media="(prefers-color-scheme: dark)"
     />
     <style media="(prefers-color-scheme: light)">{{ .CssCodeLight }}</style>
     <style media="(prefers-color-scheme: dark)">{{ .CssCodeDark }}</style>
     {{end}}
-    <link rel="stylesheet" href="/static/css/github-print.css" media="print" />
+    <link rel="stylesheet" href="static/css/github-print.css" media="print" />
   </head>
 
   <body class="markdown-body">

--- a/defaults/templates/mermaid/mermaid.html
+++ b/defaults/templates/mermaid/mermaid.html
@@ -3,7 +3,7 @@
     {{ .Content }}
   </div>
 
-  <script src="/static/js/mermaid.min.js"></script>
+  <script src="static/js/mermaid.min.js"></script>
   {{if eq .Theme "dark" }}
   <script>
     mermaid.initialize({startOnLoad:true, theme: 'dark'});

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -4,11 +4,15 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
+	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -68,7 +72,6 @@ func (s *Server) Serve(file string) error {
 		}
 
 		if err == nil && regex.MatchString(r.URL.Path) {
-			// Open file and convert to html
 			bytes, err := readToString(dir, r.URL.Path)
 			if err != nil {
 				log.Fatal(err)
@@ -95,7 +98,6 @@ func (s *Server) Serve(file string) error {
 
 	addr := fmt.Sprintf("http://%s:%d/", s.host, s.port)
 	if file == "" {
-		// If README.md exists then open README.md at beginning
 		readme := "README.md"
 		f, err := dir.Open(readme)
 		if err == nil {
@@ -108,17 +110,154 @@ func (s *Server) Serve(file string) error {
 		addr, _ = url.JoinPath(addr, filename)
 	}
 
-	fmt.Printf("🚀 Starting server: %s\n", addr)
+	fmt.Printf("Starting server: %s\n", addr)
 
 	if s.browser {
 		err := Open(addr)
 		if err != nil {
-			fmt.Println("❌ Error opening browser:", err)
+			fmt.Println("Error opening browser:", err)
 		}
 	}
 
 	handler := reload.Handle(http.DefaultServeMux)
 	return http.ListenAndServe(fmt.Sprintf(":%d", s.port), handler)
+}
+
+func (s *Server) GenerateStaticSite(file string, outputDir string) error {
+	fmt.Println("Warning: GenerateStaticSite is deprecated. Use GenerateSingleFile or GenerateDirectoryFiles instead.")
+
+	absFilePath, err := filepath.Abs(file)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %v", err)
+	}
+
+	absOutputDir, err := filepath.Abs(outputDir)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %v", err)
+	}
+
+	if err := os.MkdirAll(absOutputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %v", err)
+	}
+
+	staticDir := path.Join(absOutputDir, "static")
+	if err := os.MkdirAll(staticDir, 0755); err != nil {
+		return fmt.Errorf("failed to create static directory: %v", err)
+	}
+
+	if err := copyStaticFiles(staticDir); err != nil {
+		return fmt.Errorf("failed to copy static files: %v", err)
+	}
+
+	directory := path.Dir(absFilePath)
+	if file == "" {
+		directory = "."
+	}
+
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return fmt.Errorf("failed to read directory: %v", err)
+	}
+
+	var indexFile string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".md") {
+			content, err := os.ReadFile(path.Join(directory, entry.Name()))
+			if err != nil {
+				return fmt.Errorf("failed to read file %s: %v", entry.Name(), err)
+			}
+
+			htmlContent := s.parser.MdToHTML(content)
+
+			htmlFile := strings.TrimSuffix(entry.Name(), ".md") + ".html"
+			if entry.Name() == "README.md" {
+				htmlFile = "index.html"
+				indexFile = htmlFile
+			}
+
+			html := htmlStruct{
+				Content:      string(htmlContent),
+				Theme:        s.theme,
+				BoundingBox:  s.boundingBox,
+				CssCodeLight: getCssCode("github"),
+				CssCodeDark:  getCssCode("github-dark"),
+			}
+
+			outputFilePath := path.Join(absOutputDir, htmlFile)
+			if err := writeHTMLFile(outputFilePath, html); err != nil {
+				return fmt.Errorf("failed to write HTML file %s: %v", htmlFile, err)
+			}
+
+			fmt.Printf("Generated HTML file: %s\n", outputFilePath)
+		}
+	}
+
+	fmt.Printf("Output directory: %s\n", absOutputDir)
+
+	if s.browser {
+		indexPath := path.Join(absOutputDir, indexFile)
+		if indexFile == "" {
+			indexPath = path.Join(absOutputDir, "index.html")
+		}
+		fileURL := "file://" + indexPath
+		err := Open(fileURL)
+		if err != nil {
+			fmt.Println("Error opening browser:", err)
+		}
+	}
+
+	return nil
+}
+
+func copyStaticFiles(staticDir string) error {
+	dirs := []string{"css", "js", "images", "emojis"}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(filepath.Join(staticDir, dir), 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %v", dir, err)
+		}
+	}
+
+	err := fs.WalkDir(defaults.StaticFiles, "static", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		content, err := defaults.StaticFiles.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read embedded file %s: %v", path, err)
+		}
+
+		outputPath := filepath.Join(staticDir, strings.TrimPrefix(path, "static/"))
+		if err := os.WriteFile(outputPath, content, 0644); err != nil {
+			return fmt.Errorf("failed to write file %s: %v", outputPath, err)
+		}
+
+		return nil
+	})
+
+	return err
+}
+
+func writeHTMLFile(path string, html htmlStruct) error {
+	tmpl, err := template.ParseFS(defaults.Templates, "templates/layout.html")
+	if err != nil {
+		return fmt.Errorf("failed to parse template: %v", err)
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %v", err)
+	}
+	defer file.Close()
+
+	if err := tmpl.Execute(file, html); err != nil {
+		return fmt.Errorf("failed to execute template: %v", err)
+	}
+
+	return nil
 }
 
 func readToString(dir http.Dir, filename string) ([]byte, error) {
@@ -160,4 +299,218 @@ func getCssCode(style string) string {
 	s := styles.Get(style)
 	_ = formatter.WriteCSS(buf, s)
 	return buf.String()
+}
+
+func (s *Server) GenerateSingleFile(filePath string, outputDir string) error {
+	absOutputDir, err := filepath.Abs(outputDir)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %v", err)
+	}
+
+	if err := os.MkdirAll(absOutputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %v", err)
+	}
+
+	staticDir := path.Join(absOutputDir, "static")
+	if err := os.MkdirAll(staticDir, 0755); err != nil {
+		return fmt.Errorf("failed to create static directory: %v", err)
+	}
+
+	if err := copyStaticFiles(staticDir); err != nil {
+		return fmt.Errorf("failed to copy static files: %v", err)
+	}
+
+	absFilePath, err := filepath.Abs(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %v", err)
+	}
+
+	content, err := os.ReadFile(absFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s: %v", absFilePath, err)
+	}
+
+	htmlContent := s.parser.MdToHTML(content)
+
+	baseFileName := filepath.Base(absFilePath)
+	htmlFile := strings.TrimSuffix(baseFileName, ".md") + ".html"
+
+	if baseFileName == "README.md" {
+		htmlFile = "index.html"
+	}
+
+	outputFilePath := path.Join(absOutputDir, htmlFile)
+
+	html := htmlStruct{
+		Content:      string(htmlContent),
+		Theme:        s.theme,
+		BoundingBox:  s.boundingBox,
+		CssCodeLight: getCssCode("github"),
+		CssCodeDark:  getCssCode("github-dark"),
+	}
+
+	if err := writeHTMLFile(outputFilePath, html); err != nil {
+		return fmt.Errorf("failed to write HTML file %s: %v", htmlFile, err)
+	}
+
+	fmt.Printf("Generated HTML file: %s\n", outputFilePath)
+
+	if s.browser {
+		fileURL := "file://" + outputFilePath
+		err := Open(fileURL)
+		if err != nil {
+			fmt.Println("Error opening browser:", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *Server) GenerateDirectoryFiles(dirPath string, outputDir string) error {
+	absDirPath, err := filepath.Abs(dirPath)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %v", err)
+	}
+
+	absOutputDir, err := filepath.Abs(outputDir)
+	if err != nil {
+		return fmt.Errorf("failed to get absolute path: %v", err)
+	}
+
+	if err := os.MkdirAll(absOutputDir, 0755); err != nil {
+		return fmt.Errorf("failed to create output directory: %v", err)
+	}
+
+	staticDir := path.Join(absOutputDir, "static")
+	if err := os.MkdirAll(staticDir, 0755); err != nil {
+		return fmt.Errorf("failed to create static directory: %v", err)
+	}
+
+	if err := copyStaticFiles(staticDir); err != nil {
+		return fmt.Errorf("failed to copy static files: %v", err)
+	}
+
+	entries, err := os.ReadDir(absDirPath)
+	if err != nil {
+		return fmt.Errorf("failed to read directory: %v", err)
+	}
+
+	foundMarkdown := false
+
+	var indexFile string
+	generatedFiles := make(map[string]string) // filename -> title
+
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".md") {
+			foundMarkdown = true
+
+			mdFilePath := path.Join(absDirPath, entry.Name())
+			content, err := os.ReadFile(mdFilePath)
+			if err != nil {
+				return fmt.Errorf("failed to read file %s: %v", mdFilePath, err)
+			}
+
+			title := extractTitle(content, entry.Name())
+
+			htmlContent := s.parser.MdToHTML(content)
+
+			htmlFile := strings.TrimSuffix(entry.Name(), ".md") + ".html"
+
+			if entry.Name() == "README.md" {
+				htmlFile = "index.html"
+				indexFile = htmlFile
+			}
+
+			outputFilePath := path.Join(absOutputDir, htmlFile)
+
+			generatedFiles[htmlFile] = title
+
+			html := htmlStruct{
+				Content:      string(htmlContent),
+				Theme:        s.theme,
+				BoundingBox:  s.boundingBox,
+				CssCodeLight: getCssCode("github"),
+				CssCodeDark:  getCssCode("github-dark"),
+			}
+
+			if err := writeHTMLFile(outputFilePath, html); err != nil {
+				return fmt.Errorf("failed to write HTML file %s: %v", outputFilePath, err)
+			}
+
+			fmt.Printf("Generated HTML file: %s\n", outputFilePath)
+		}
+	}
+
+	if !foundMarkdown {
+		return fmt.Errorf("no markdown files found in directory %s", absDirPath)
+	}
+
+	if indexFile == "" {
+		dirName := filepath.Base(absDirPath)
+		indexContent := generateDirectoryIndex(dirName, generatedFiles)
+
+		html := htmlStruct{
+			Content:      string(indexContent),
+			Theme:        s.theme,
+			BoundingBox:  s.boundingBox,
+			CssCodeLight: getCssCode("github"),
+			CssCodeDark:  getCssCode("github-dark"),
+		}
+
+		indexFile = "index.html"
+		indexPath := path.Join(absOutputDir, indexFile)
+
+		if err := writeHTMLFile(indexPath, html); err != nil {
+			return fmt.Errorf("failed to write index file: %v", err)
+		}
+
+		fmt.Printf("Generated index file: %s\n", indexPath)
+	}
+
+	fmt.Printf("Output directory: %s\n", absOutputDir)
+
+	if s.browser {
+		fileURL := "file://" + path.Join(absOutputDir, indexFile)
+		err := Open(fileURL)
+		if err != nil {
+			fmt.Println("Error opening browser:", err)
+		}
+	}
+
+	return nil
+}
+
+func extractTitle(content []byte, filename string) string {
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "# ") {
+			return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "# "))
+		}
+	}
+
+	return strings.TrimSuffix(filename, filepath.Ext(filename))
+}
+
+func generateDirectoryIndex(dirName string, files map[string]string) string {
+	var sb strings.Builder
+
+	sb.WriteString("<h1>Directory: " + dirName + "</h1>\n")
+	sb.WriteString("<p>The following files were generated:</p>\n")
+	sb.WriteString("<ul>\n")
+
+	var filenames []string
+	for filename := range files {
+		if filename != "index.html" {
+			filenames = append(filenames, filename)
+		}
+	}
+	sort.Strings(filenames)
+
+	for _, filename := range filenames {
+		title := files[filename]
+		sb.WriteString(fmt.Sprintf("  <li><a href=\"%s\">%s</a></li>\n", filename, title))
+	}
+
+	sb.WriteString("</ul>\n")
+	return sb.String()
 }


### PR DESCRIPTION
This PR refactors and redesigns the `cli` implementation.

Also implements the `planned` feature to export the generated HTML (https://github.com/chrishrb/go-grip/issues/44),

Added Features :
- Adds the ability to export the rendered Markdown as a standalone HTML file.
- Changes the default command to standalone using $CACHE_DIR/go-grip/ path for html sources
- Introduces optional output dir -o , --output to exported static files to.
- Support for grouped `md` files rendering + a simple index page
- Update README.md accordingly 
- Other small modifications


NOTE: as you see this PR has a single commit, the reason is I commited the built `binary` and after removing it's index from history (`~root`) realized I had the repo fully cloned (mistook my original clone for a `--depth=1` as I alsmost always perform a shallow clone). And well you know what it means I guess! 

Anyways in case you are intrested in actual commit history of this pr, [here they are](https://github.com/chrishrb/go-grip/pull/45/) (after [c446496](https://github.com/chrishrb/go-grip/pull/45/commits/c4464967faddd88f9399ec3d122185acd78b5a79) )

