### PR TITLE
Fix Issue 43

### DIFF
--- a/pkg/parser.go
+++ b/pkg/parser.go
@@ -36,7 +36,8 @@ func NewParser(theme string) *Parser {
 func (m Parser) MdToHTML(bytes []byte) []byte {
 	extensions := parser.NoIntraEmphasis | parser.Tables | parser.FencedCode |
 		parser.Autolink | parser.Strikethrough | parser.SpaceHeadings | parser.HeadingIDs |
-		parser.BackslashLineBreak | parser.MathJax | parser.OrderedListStart
+		parser.BackslashLineBreak | parser.MathJax | parser.OrderedListStart |
+		parser.AutoHeadingIDs
 	p := parser.NewWithExtensions(extensions)
 	doc := p.Parse(bytes)
 


### PR DESCRIPTION
Fixes https://github.com/chrishrb/go-grip/issues/43

Github markdown [docs](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#section-links) state "You can link directly to any section that has a heading", but this isn't currently working because IDs are not being added automatically to the HTML headings.

This commit adds AutoHeadingIDs to markdown extensions, documented in [gomarkdown docs](https://pkg.go.dev/github.com/gomarkdown/markdown/parser#Extensions)

**Example**:
Before fix, the first heading of README.md in this repo renders:

    <h2>❓ About</h2>

After fix, id is auto-added to HTML headings so they can serve as targets for internal links.

    <h2 id="question-about">❓ About</h2>