### PR TITLE
Add viewport meta for proper mobile scaling

### DIFF
--- a/defaults/templates/layout.html
+++ b/defaults/templates/layout.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>go-grip - markdown preview</title>
     <link rel="icon" type="image/x-icon" href="/static/images/favicon.ico" />
     {{if eq .Theme "dark" }}


### PR DESCRIPTION
# Before

<img width="50%" height="2016" alt="image" src="https://github.com/user-attachments/assets/c4033a68-527e-47ef-9744-0cbb218eca20" />

# After

<img width="50%" height="2016" alt="image" src="https://github.com/user-attachments/assets/7772d63a-8427-4344-bbe1-5f041cd05e0f" />
