### PR TITLE
#66 Restore single newline behavior in markdown renderer

### DIFF
--- a/internal/parser.go
+++ b/internal/parser.go
@@ -46,7 +46,6 @@ func (m Parser) MdToHTML(input []byte) ([]byte, error) {
 			parser.WithAutoHeadingID(),
 		),
 		goldmark.WithRendererOptions(
-			html.WithHardWraps(),
 			html.WithUnsafe(),
 		),
 	)


### PR DESCRIPTION
Removes `html.WithHardWraps()` from the goldmark renderer options, which was causing every newline to be treated as a `<br>`.
Single newlines are now ignored as paragraph breaks, matching my understanding of the standard CommonMark/README rendering behavior.

Fixes #66.